### PR TITLE
fix: remove unneeded calls to Update for EF entities

### DIFF
--- a/Areas/Identity/Data/JwtAuthenticationManager.cs
+++ b/Areas/Identity/Data/JwtAuthenticationManager.cs
@@ -124,7 +124,6 @@ namespace echoStudy_webAPI.Data
             }
 
             storedRefreshToken.Used = true;
-            _context.RefreshTokens.Update(storedRefreshToken);
             await _context.SaveChangesAsync();
 
             // ensure the user id encoded in the JWT exists in the database

--- a/Controllers/DecksController.cs
+++ b/Controllers/DecksController.cs
@@ -401,8 +401,6 @@ namespace echoStudy_webAPI.Controllers
             deck.OrigDeckId = null;
             deck.OrigAuthorId = null;
 
-            // Save the deck
-            _context.Decks.Update(deck);
 
             // Try to save
             try
@@ -680,7 +678,6 @@ namespace echoStudy_webAPI.Controllers
         {
             var query = _context.Decks.Where(x => deckIds.Contains(x.DeckID));
             List<Deck> derivedDecksList = await query.ToListAsync();
-            _context.UpdateRange(derivedDecksList);
 
             foreach(Deck d in derivedDecksList)
             {


### PR DESCRIPTION
## summary of changes
- remove `Update` calls to directly queried entities
- aggregate datetimes to one call of `DateTime.Now`

---

EF automatically tracks entities for change if they were queried directly from the context/dbset.
When calling `_context.Update(entity)` it generates a SQL query that updates **all** entity fields with the data at initial query.
For more info, see this resource: https://blog.oneunicorn.com/2020/01/17/dontcallupdate/

This fixes a race for when we edit a deck and we update both the deck metadata and add new cards causing the deck metadata not to change.

Server steps:
- The server (for both endpoints) queries the deck to be changed. 
- The deck metadata is changed and written to DB.
- New cards request finishes last (overhead due to Polly audio files)
  - Calling `_context.Update(deck)` marks all fields changed and yields a SQL query updating all fields
  - But since the deck was queried before deck metadata changes... it overwrites it, causing the bug