### PR TITLE
fix(StudyActivity): parse query params from object type

### DIFF
--- a/Controllers/StudyActivityController.cs
+++ b/Controllers/StudyActivityController.cs
@@ -37,7 +37,7 @@ namespace echoStudy_webAPI.Controllers
         [ProducesResponseType(typeof(IEnumerable<string>), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(UnauthorizedResult), StatusCodes.Status401Unauthorized)]
         [HttpGet]
-        public async Task<IActionResult> GetActivity(ActivityRetrievalRequest request)
+        public async Task<IActionResult> GetActivity([FromQuery] ActivityRetrievalRequest request)
         {
             DateTime? start = request.StartDate is null ? DateTime.MinValue : request.StartDate;
             DateTime? end = request.EndDate is null ? DateTime.MaxValue : request.EndDate;

--- a/Data/Requests/ActivityRetrievalRequest.cs
+++ b/Data/Requests/ActivityRetrievalRequest.cs
@@ -1,10 +1,14 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Mvc;
+using System;
 
 namespace echoStudy_webAPI.Data.Requests
 {
     public class ActivityRetrievalRequest
     {
+        [FromQuery(Name = "startDate")]
         public DateTime? StartDate { get; set; }
+
+        [FromQuery(Name = "endDate")]
         public DateTime? EndDate { get; set; }
     }
 }


### PR DESCRIPTION
allows ASP.NET Core to parse `GET /StudyActivity` via query params and not the request body 

schema is now updated to be:

`/StudyActivity?startDate=<DateTime>&endDate=<DateTime>`
(e.g.) `/StudyActivity?startDate=2022-11-04T17:22:43.577Z&endDate=2022-11-04T17:22:43.577Z`